### PR TITLE
Fix first incorrect delegate call

### DIFF
--- a/Sources/SectionedSlider.swift
+++ b/Sources/SectionedSlider.swift
@@ -482,11 +482,15 @@ open class SectionedSlider: UIView {
         
         super.init(frame: frame)
         
-        self.backgroundColor = palette.viewBackgroundColor
-        
-        self.selectedSection = selectedSection
-        self.sections = sections
-        self.palette = palette
+        //Because we use observers, for them to run in the initializers defer is needed.
+        // See: https://stackoverflow.com/a/33979852/1904232
+        defer {
+            self.backgroundColor = palette.viewBackgroundColor
+            
+            self.selectedSection = selectedSection
+            self.sections = sections
+            self.palette = palette
+        }
 
         draw()
         


### PR DESCRIPTION
Hey! Thanks for this great control.

Just came across a small bug, looks like observers don't run in the initializer for swift which causes a first delegate call with 0.0 (Factor's default value) instead of the value you can put in the initializer for selected section. 

Let me know what you think 👍 
