### PR TITLE
Enable use in UITableView

### DIFF
--- a/Sources/SectionedSlider.swift
+++ b/Sources/SectionedSlider.swift
@@ -429,7 +429,7 @@ open class SectionedSlider: UIView {
         }
     }
     
-    @IBInspectable var sections: Int = 10 {
+    @IBInspectable open var sections: Int = 10 {
         willSet {
             if newValue < 2 || newValue > 20 {
                 debugPrint("sections must be between 2 and 20")
@@ -437,7 +437,7 @@ open class SectionedSlider: UIView {
         }
     }
 
-    @IBInspectable var selectedSection: Int = 0 {
+    @IBInspectable open var selectedSection: Int = 0 {
         didSet {
             if selectedSection < 0 || selectedSection > sections {
                 debugPrint("sections must be between 0 and \(sections)")

--- a/Sources/SectionedSlider.swift
+++ b/Sources/SectionedSlider.swift
@@ -491,6 +491,8 @@ open class SectionedSlider: UIView {
             self.sections = sections
             self.palette = palette
         }
+        
+        addPanGesture()
 
         draw()
         
@@ -506,6 +508,8 @@ open class SectionedSlider: UIView {
     override open func awakeFromNib() {
         
         super.awakeFromNib()
+        
+        addPanGesture()
 
         draw()
         
@@ -537,6 +541,12 @@ open class SectionedSlider: UIView {
     }
     
     // MARK: - Functions
+    
+    private func addPanGesture() {
+        let gesture = UIPanGestureRecognizer(target: self, action: #selector(SectionedSlider.dragged(gesture:)))
+        self.addGestureRecognizer(gesture)
+    }
+    
     private func resetManipulables() {
         
         guard let layer: SectionedSliderLayer = layer as? SectionedSliderLayer else { return }
@@ -562,20 +572,6 @@ open class SectionedSlider: UIView {
 
         super.touchesBegan(touches, with: event)
 
-        touchedX(touches)
-
-    }
-
-    open override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
-
-        super.touchesMoved(touches, with: event)
-
-        touchedX(touches)
-
-    }
-
-    private func touchedX(_ touches: Set<UITouch>) {
-
         guard
             let touch = touches.first
             else { return }
@@ -585,6 +581,15 @@ open class SectionedSlider: UIView {
 
         factor = x / self.frame.height
 
+    }
+    
+    @objc private func dragged(gesture: UIPanGestureRecognizer) {
+        
+        let point = gesture.location(in: self)
+        var x = self.frame.height - point.y
+        x = x < 0 ? -1 : (x > self.frame.height ? self.frame.height : x)
+        factor = x / self.frame.height
+        
     }
     
 }


### PR DESCRIPTION
Variables sections and selectedSection were made open so it's possible to actually programmatically change the value rather than just listen to changes via the delegate function. Without this, the only way to really change it is to recreate the entire SectionedSlider.

TouchedMoved were swapped out for pan gestures so the gesture recognizers could operate with that of a scrollView. Otherwise, the pan gesture of the scrollView would activate when you're trying to use the Sectioned Slider. Note that this was only tested via Storyboards (aka using `awakeFromNib`), I haven't tested it via programmatic creation `init(frame: CGRect, selectedSection: Int, sections: Int, palette: Palette = Palette())`