### PR TITLE
Fix delegate reference cycle (memory leak) and upgrade to swift 5.0

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -100,7 +100,6 @@
 				98287C6E1EE7443100FA064B /* Frameworks */,
 				98287C6F1EE7443100FA064B /* Resources */,
 				B201297C64912C9375419BD5 /* [CP] Embed Pods Frameworks */,
-				BFF0CED05D51E426A2051F19 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -123,6 +122,7 @@
 				TargetAttributes = {
 					98287C701EE7443100FA064B = {
 						CreatedOnToolsVersion = 8.3.2;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Manual;
 					};
 				};
@@ -183,7 +183,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Example/Pods-Example-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/SectionedSlider/SectionedSlider.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -192,22 +192,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example/Pods-Example-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		BFF0CED05D51E426A2051F19 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example/Pods-Example-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -363,7 +348,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.leocardz.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -379,7 +365,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.leocardz.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -122,7 +122,7 @@
 				TargetAttributes = {
 					98287C701EE7443100FA064B = {
 						CreatedOnToolsVersion = 8.3.2;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1150;
 						ProvisioningStyle = Manual;
 					};
 				};
@@ -132,6 +132,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -349,7 +350,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -366,7 +367,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.17" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Q0q-Vo-r2K">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,7 +20,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hNB-Jo-ek4" customClass="SectionedSlider" customModule="SectionedSlider">
-                                <rect key="frame" x="148" y="233" width="78" height="200"/>
+                                <rect key="frame" x="148.5" y="233.5" width="78" height="200"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="200" id="g2I-WF-3HH"/>
                                     <constraint firstAttribute="width" constant="78" id="ioG-Re-8xl"/>
@@ -46,7 +44,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Section #0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qcB-4O-rjo">
-                                <rect key="frame" x="137" y="177" width="100" height="21"/>
+                                <rect key="frame" x="137.5" y="177.5" width="100" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="100" id="3hU-xg-aAB"/>
                                     <constraint firstAttribute="height" constant="21" id="Heh-0G-iMQ"/>
@@ -64,6 +62,7 @@
                             <constraint firstItem="qcB-4O-rjo" firstAttribute="centerX" secondItem="hNB-Jo-ek4" secondAttribute="centerX" id="yJ8-iL-2zs"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="UPT-ez-iAX"/>
                     <connections>
                         <outlet property="label" destination="qcB-4O-rjo" id="BTI-QJ-NmN"/>
                         <outlet property="sectionedSlider" destination="hNB-Jo-ek4" id="QmC-LC-Xoc"/>
@@ -71,6 +70,68 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="138" y="134"/>
+        </scene>
+        <!--Root View Controller-->
+        <scene sceneID="PIM-ZE-2hw">
+            <objects>
+                <tableViewController id="zgS-7A-2Du" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="ulj-gt-Gww">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <sections>
+                            <tableViewSection headerTitle="Sliders" id="HnE-Nx-sqM">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="DUL-6x-XeI" style="IBUITableViewCellStyleDefault" id="Vwd-f7-9rR">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Vwd-f7-9rR" id="6Jj-n5-E5P">
+                                            <rect key="frame" x="0.0" y="0.0" width="348" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Slider here" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="DUL-6x-XeI">
+                                                    <rect key="frame" x="16" y="0.0" width="324" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="BYZ-38-t0r" kind="show" id="z2c-ks-ovQ"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="zgS-7A-2Du" id="Egh-B1-D9F"/>
+                            <outlet property="delegate" destination="zgS-7A-2Du" id="pBT-CT-qWX"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Root View Controller" id="JTA-lc-hxm"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="1pg-u2-365" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="23" y="-631"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="Tna-1E-IjM">
+            <objects>
+                <navigationController id="Q0q-Vo-r2K" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="ySx-il-VBS">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="zgS-7A-2Du" kind="relationship" relationship="rootViewController" id="2Iv-uf-Wv1"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="7Au-Yj-d76" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1022" y="134"/>
         </scene>
     </scenes>
 </document>

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - SectionedSlider (0.0.3)
+  - SectionedSlider (0.0.5)
 
 DEPENDENCIES:
   - SectionedSlider (from `../`)
 
 EXTERNAL SOURCES:
   SectionedSlider:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  SectionedSlider: 661f3bfeaee4b2f81bba4d75a466e7f5811d81e0
+  SectionedSlider: 1fd0d2fe31e8d2ad9b71349ffa160cc906745e22
 
 PODFILE CHECKSUM: be75490de1e91b92d1de255a1c69cf94cb3d373b
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.9.0

--- a/SectionedSlider.xcodeproj/project.pbxproj
+++ b/SectionedSlider.xcodeproj/project.pbxproj
@@ -106,7 +106,7 @@
 				TargetAttributes = {
 					98287C571EE73B1D00FA064B = {
 						CreatedOnToolsVersion = 8.3.2;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1150;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -116,6 +116,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 98287C4E1EE73B1D00FA064B;
@@ -269,7 +270,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -290,7 +291,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/SectionedSlider.xcodeproj/project.pbxproj
+++ b/SectionedSlider.xcodeproj/project.pbxproj
@@ -51,7 +51,6 @@
 				98287C631EE73B5400FA064B /* Supporting Files */,
 				98287C661EE73D0900FA064B /* SectionedSlider.swift */,
 			);
-			name = Sources;
 			path = Sources;
 			sourceTree = "<group>";
 		};
@@ -61,7 +60,6 @@
 				98287C5C1EE73B1D00FA064B /* Info.plist */,
 				98287C5B1EE73B1D00FA064B /* SectionedSlider.h */,
 			);
-			name = "Supporting Files";
 			path = "Supporting Files";
 			sourceTree = "<group>";
 		};
@@ -108,7 +106,7 @@
 				TargetAttributes = {
 					98287C571EE73B1D00FA064B = {
 						CreatedOnToolsVersion = 8.3.2;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -270,7 +268,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -290,7 +289,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.leocardz.SectionedSlider;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -313,6 +313,7 @@
 				98287C621EE73B1D00FA064B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Sources/SectionedSlider.swift
+++ b/Sources/SectionedSlider.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public protocol SectionedSliderDelegate {
+public protocol SectionedSliderDelegate: AnyObject {
     
 	func sectionChanged(slider: SectionedSlider, selected: Int)
     
@@ -459,7 +459,7 @@ open class SectionedSlider: UIView {
     // MARK: - Properties
     private var keyPath: String = "factor"
     private var palette: Palette = Palette()
-    open var delegate: SectionedSliderDelegate? {
+    open weak var delegate: SectionedSliderDelegate? {
         didSet {
             let factor = self.factor
             self.factor = factor


### PR DESCRIPTION
Hey,

I've separated the content to 4 commits:
1. Upgrade Swift 3.0 -> 4.2
2. Upgrade Swift 4.2 -> 5.0
3. Change the Example project to have a navigation controller leading to the view controller, so it's easy to show the leak
4. Fix the leak

To reproduce:
- Go to the 3rd commit and run the example
- Enter the slider VC, then back out, repeat a couple of times
- Use Xcode's "Debug Memory Graph"

You'll see that there are multiple `ViewController`s up, rather than one:
![image](https://user-images.githubusercontent.com/31284/84827952-ef1ea000-b02d-11ea-90f9-8573d17c204c.png)

The 4th commit fixes this. More info on delegates and retains cycles [here](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html#ID276).

Hope you can approve this PR and update the Pod!
